### PR TITLE
Add segwit p2wsh and p2wpkh challenge support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/btcsuite/btcd v0.21.0-beta
+  github.com/btcsuite/btcutil v1.0.2
 	github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa // indirect
 	github.com/ethereum/go-ethereum v1.9.23
 	golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee

--- a/signer/bitcoin/bitcoin.go
+++ b/signer/bitcoin/bitcoin.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"math/big"
 
+	"github.com/btcsuite/btcutil/bech32"
+
 	"github.com/blockcypher/cryptosigner/util"
 )
 
@@ -51,6 +53,12 @@ func VerifyChallenge(addresses []string, toSign []byte) bool {
 			if !checkP2SHOutput(addresses[n], output) {
 				return false
 			}
+		} else if toSign[idx-21] == 0 && toSign[idx-20] == 20 {
+			idx -= 28
+			output := toSign[idx:]
+			if !checkP2WPKHOutput(addresses[n], output) {
+				return false
+			}
 		} else {
 			break
 		}
@@ -74,6 +82,14 @@ func checkP2PKOutput(addr string, output []byte) bool {
 func checkP2SHOutput(addr string, output []byte) bool {
 	decoded := base58Decode(addr)
 	return bytes.Compare(output[12:32], decoded[1:21]) == 0
+}
+
+func checkP2WPKHOutput(addr string, output []byte) bool {
+	_, decoded, err := fromBech32Addr(addr)
+	if err != nil {
+		return false
+	}
+	return bytes.Compare(output[9:29], decoded) == 0
 }
 
 func base58Decode(b string) []byte {
@@ -169,4 +185,17 @@ func base58Encode(b []byte) string {
 	}
 
 	return string(answer)
+}
+
+func fromBech32Addr(addr string) (string, []byte, error) {
+	hrp, decoded, err := bech32.Decode(addr)
+	if err != nil {
+		return "", nil, err
+	}
+	// strip version
+	conv, err := bech32.ConvertBits(decoded[1:], 5, 8, false)
+	if err != nil {
+		return "", nil, err
+	}
+	return hrp, conv, nil
 }

--- a/signer/hold_test.go
+++ b/signer/hold_test.go
@@ -2,6 +2,7 @@ package signer
 
 import (
 	"encoding/hex"
+	"fmt"
 	"testing"
 
 	"github.com/blockcypher/cryptosigner/util"
@@ -43,9 +44,15 @@ const (
 	TxData2 = "0100000001000000000000000000000000000000000000000000000000000000000000000000000000" +
 		"1976a914a78ddeb84ba308abb780429d1bcdebce20a153fb88ac000000000100f2052a010000001976" +
 		"a914a78ddeb84ba308abb780429d1bcdebce20a153fb88ac00000000"
+	ADDR3   = "bc1qumnwpsyz0sresdl6yv4e7qlrg6nq0uy5vvdtrw"
+	TxData3 = "0100000001f26efab8144d394209a4369de8082a3e6b55c28e067270c4add9e92c296411ba01000000" +
+		"1976a9145dc74f0505b74972666dfc198378116c5690c88f88acffffffff" +
+		"0174b601000000000016" +
+		"0014e6e6e0c0827c079837fa232b9f03e346a607f09400000000"
 )
 
 func TestSig(t *testing.T) {
+	fmt.Println("-----------------------")
 	hold := testHold()
 	sig, _, err := testNewAndSign(t, hold, ADDR1, TxData1)
 	if err != nil {
@@ -72,6 +79,17 @@ func TestSigFailChallenge(t *testing.T) {
 	}
 	if err.Error() != "challenge failed" {
 		t.Error("Unexpected error.")
+	}
+}
+
+func TestSigBech32(t *testing.T) {
+	hold := testHold()
+	sig, _, err := testNewAndSign(t, hold, ADDR3, TxData3)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(sig) < 50 {
+		t.Error("Invalid sig.")
 	}
 }
 


### PR DESCRIPTION
Decodes bech32 addresses and checks them against the witness program in the output.